### PR TITLE
feat: add runtime info

### DIFF
--- a/src/components/CommandDisplay.tsx
+++ b/src/components/CommandDisplay.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { formatHiveCommand, copyToClipboard } from '../utils/metadata';
+
+interface CommandDisplayProps {
+  command: string[];
+  className?: string;
+}
+
+const CommandDisplay: React.FC<CommandDisplayProps> = ({ command, className = '' }) => {
+  const [copied, setCopied] = useState(false);
+  const formattedCommand = formatHiveCommand(command);
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    const success = await copyToClipboard(formattedCommand);
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: 'relative',
+        backgroundColor: 'var(--stat-bg, #f9fafb)',
+        border: '1px solid var(--border-color, rgba(229, 231, 235, 0.4))',
+        borderRadius: '0.375rem',
+        padding: '0.75rem',
+        fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        fontSize: '0.875rem',
+        lineHeight: '1.5',
+        overflow: 'auto'
+      }}
+    >
+      <button
+        onClick={handleCopy}
+        style={{
+          position: 'absolute',
+          top: '0.5rem',
+          right: '0.5rem',
+          padding: '0.25rem 0.5rem',
+          backgroundColor: copied ? 'var(--success-bg, #ecfdf5)' : 'var(--badge-bg, #f3f4f6)',
+          color: copied ? 'var(--success-text, #047857)' : 'var(--text-secondary, #6b7280)',
+          border: copied ? '1px solid var(--success-border, #10b981)' : '1px solid var(--border-color, rgba(229, 231, 235, 0.6))',
+          borderRadius: '0.25rem',
+          fontSize: '0.75rem',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.25rem',
+          transition: 'all 0.2s ease',
+          fontFamily: 'inherit'
+        }}
+        onMouseOver={(e) => {
+          if (!copied) {
+            e.currentTarget.style.backgroundColor = 'var(--badge-bg, #f3f4f6)';
+          }
+        }}
+        onMouseOut={(e) => {
+          if (!copied) {
+            e.currentTarget.style.backgroundColor = 'var(--badge-bg, #f3f4f6)';
+          }
+        }}
+      >
+        {copied ? (
+          <>
+            <span>✓</span>
+            Copied!
+          </>
+        ) : (
+          <>
+            <span>📋</span>
+            Copy
+          </>
+        )}
+      </button>
+      
+      <pre
+        style={{
+          margin: 0,
+          padding: 0,
+          paddingRight: '5rem',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-all',
+          color: 'var(--text-primary, #111827)',
+          fontSize: 'inherit',
+          lineHeight: 'inherit',
+          fontFamily: 'inherit'
+        }}
+      >
+        {formattedCommand}
+      </pre>
+    </div>
+  );
+};
+
+export default CommandDisplay;

--- a/src/components/ConfigViewer.tsx
+++ b/src/components/ConfigViewer.tsx
@@ -1,0 +1,214 @@
+import React, { useState, useEffect } from 'react';
+import { parseConfigContent, copyToClipboard } from '../utils/metadata';
+import { usePrismTheme } from './PrismTheme';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-json';
+
+interface ConfigViewerProps {
+  config: unknown;
+  filePath?: string;
+  isDarkMode: boolean;
+  className?: string;
+  collapsed?: boolean;
+}
+
+const ConfigViewer: React.FC<ConfigViewerProps> = ({ 
+  config, 
+  filePath, 
+  isDarkMode, 
+  className = '',
+  collapsed = false 
+}) => {
+  const [copied, setCopied] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(collapsed);
+  const [highlightedCode, setHighlightedCode] = useState('');
+  const { codeClassName } = usePrismTheme(isDarkMode);
+  
+  const { isValid, formatted } = parseConfigContent(config);
+
+  useEffect(() => {
+    if (isValid && !isCollapsed) {
+      const highlighted = Prism.highlight(formatted, Prism.languages.json, 'json');
+      setHighlightedCode(highlighted);
+    }
+  }, [formatted, isValid, isCollapsed]);
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    const success = await copyToClipboard(formatted);
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const toggleCollapse = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsCollapsed(!isCollapsed);
+  };
+
+  return (
+    <div
+      className={className}
+      style={{
+        border: '1px solid var(--border-color, rgba(229, 231, 235, 0.4))',
+        borderRadius: '0.375rem',
+        overflow: 'hidden'
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '0.75rem',
+          backgroundColor: 'var(--badge-bg, #f3f4f6)',
+          borderBottom: isCollapsed ? 'none' : '1px solid var(--border-color, rgba(229, 231, 235, 0.4))'
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <button
+            onClick={toggleCollapse}
+            style={{
+              padding: '0.25rem',
+              backgroundColor: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: '0.25rem',
+              fontSize: '0.875rem',
+              color: 'var(--text-secondary, #6b7280)',
+              transition: 'all 0.2s ease'
+            }}
+            onMouseOver={(e) => {
+              e.currentTarget.style.backgroundColor = 'var(--hover-bg, #f3f4f6)';
+            }}
+            onMouseOut={(e) => {
+              e.currentTarget.style.backgroundColor = 'transparent';
+            }}
+          >
+            {isCollapsed ? '▶' : '▼'}
+          </button>
+          
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.125rem' }}>
+            <span style={{ 
+              fontSize: '0.875rem', 
+              fontWeight: '500',
+              color: 'var(--text-primary, #111827)'
+            }}>
+              Client Configuration
+            </span>
+            {filePath && (
+              <span style={{ 
+                fontSize: '0.75rem', 
+                color: 'var(--text-secondary, #6b7280)',
+                fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
+              }}>
+                {filePath}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <button
+          onClick={handleCopy}
+          style={{
+            padding: '0.25rem 0.5rem',
+            backgroundColor: copied ? 'var(--success-bg, #ecfdf5)' : 'var(--badge-bg, #f3f4f6)',
+            color: copied ? 'var(--success-text, #047857)' : 'var(--text-secondary, #6b7280)',
+            border: copied ? '1px solid var(--success-border, #10b981)' : '1px solid var(--border-color, rgba(229, 231, 235, 0.6))',
+            borderRadius: '0.25rem',
+            fontSize: '0.75rem',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+            transition: 'all 0.2s ease'
+          }}
+          onMouseOver={(e) => {
+            if (!copied) {
+              e.currentTarget.style.backgroundColor = 'var(--stat-bg, #f9fafb)';
+            }
+          }}
+          onMouseOut={(e) => {
+            if (!copied) {
+              e.currentTarget.style.backgroundColor = 'var(--badge-bg, #f3f4f6)';
+            }
+          }}
+        >
+          {copied ? (
+            <>
+              <span>✓</span>
+              Copied!
+            </>
+          ) : (
+            <>
+              <span>📋</span>
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Content */}
+      {!isCollapsed && (
+        <div
+          style={{
+            padding: '0.75rem',
+            backgroundColor: 'var(--stat-bg, #f9fafb)',
+            maxHeight: '400px',
+            overflow: 'auto'
+          }}
+        >
+          {isValid ? (
+            <pre
+              className={codeClassName}
+              style={{
+                margin: 0,
+                padding: 0,
+                fontSize: '0.875rem',
+                lineHeight: '1.5',
+                fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word'
+              }}
+              dangerouslySetInnerHTML={{ __html: highlightedCode }}
+            />
+          ) : (
+            <div style={{
+              color: 'var(--error-text, #b91c1c)',
+              fontSize: '0.875rem',
+              padding: '0.5rem',
+              backgroundColor: 'var(--error-bg, #fef2f2)',
+              border: '1px solid var(--error-border, #ef4444)20',
+              borderRadius: '0.25rem'
+            }}>
+              <div style={{ fontWeight: '500', marginBottom: '0.25rem' }}>
+                Invalid JSON Configuration
+              </div>
+              <pre
+                style={{
+                  margin: 0,
+                  fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                  fontSize: '0.75rem',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word'
+                }}
+              >
+                {formatted}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ConfigViewer;

--- a/src/components/ConfigViewer.tsx
+++ b/src/components/ConfigViewer.tsx
@@ -12,18 +12,18 @@ interface ConfigViewerProps {
   collapsed?: boolean;
 }
 
-const ConfigViewer: React.FC<ConfigViewerProps> = ({ 
-  config, 
-  filePath, 
-  isDarkMode, 
+const ConfigViewer: React.FC<ConfigViewerProps> = ({
+  config,
+  filePath,
+  isDarkMode,
   className = '',
-  collapsed = false 
+  collapsed = false
 }) => {
   const [copied, setCopied] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(collapsed);
   const [highlightedCode, setHighlightedCode] = useState('');
   const { codeClassName } = usePrismTheme(isDarkMode);
-  
+
   const { isValid, formatted } = parseConfigContent(config);
 
   useEffect(() => {
@@ -36,7 +36,7 @@ const ConfigViewer: React.FC<ConfigViewerProps> = ({
   const handleCopy = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    
+
     const success = await copyToClipboard(formatted);
     if (success) {
       setCopied(true);
@@ -95,18 +95,18 @@ const ConfigViewer: React.FC<ConfigViewerProps> = ({
           >
             {isCollapsed ? '▶' : '▼'}
           </button>
-          
+
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.125rem' }}>
-            <span style={{ 
-              fontSize: '0.875rem', 
+            <span style={{
+              fontSize: '0.875rem',
               fontWeight: '500',
               color: 'var(--text-primary, #111827)'
             }}>
-              Client Configuration
+              Client File
             </span>
             {filePath && (
-              <span style={{ 
-                fontSize: '0.75rem', 
+              <span style={{
+                fontSize: '0.75rem',
                 color: 'var(--text-secondary, #6b7280)',
                 fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
               }}>
@@ -168,7 +168,6 @@ const ConfigViewer: React.FC<ConfigViewerProps> = ({
         >
           {isValid ? (
             <pre
-              className={codeClassName}
               style={{
                 margin: 0,
                 padding: 0,
@@ -176,10 +175,15 @@ const ConfigViewer: React.FC<ConfigViewerProps> = ({
                 lineHeight: '1.5',
                 fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
                 whiteSpace: 'pre-wrap',
-                wordBreak: 'break-word'
+                wordBreak: 'break-word',
+                background: 'none'
               }}
-              dangerouslySetInnerHTML={{ __html: highlightedCode }}
-            />
+            >
+              <code
+                className={codeClassName}
+                dangerouslySetInnerHTML={{ __html: highlightedCode }}
+              />
+            </pre>
           ) : (
             <div style={{
               color: 'var(--error-text, #b91c1c)',

--- a/src/components/GroupHeader.tsx
+++ b/src/components/GroupHeader.tsx
@@ -171,7 +171,8 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({
                 backgroundColor: isDarkMode ? 'rgba(16, 185, 129, 0.2)' : 'var(--success-bg, #d1fae5)',
                 borderRadius: '0.375rem',
                 padding: '0.15rem 0.4rem',
-                gap: '0.25rem'
+                gap: '0.25rem',
+                width: '50px'
               }}>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
                      style={{ width: '0.75rem', height: '0.75rem', color: 'var(--success-border, #10b981)' }}>
@@ -185,7 +186,8 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({
                 backgroundColor: isDarkMode ? 'rgba(245, 158, 11, 0.2)' : 'var(--warning-bg, #fef3c7)',
                 borderRadius: '0.375rem',
                 padding: '0.15rem 0.4rem',
-                gap: '0.25rem'
+                gap: '0.25rem',
+                width: '50px'
               }}>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
                      style={{ width: '0.75rem', height: '0.75rem', color: 'var(--warning-border, #f59e0b)' }}>
@@ -199,7 +201,8 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({
                 backgroundColor: isDarkMode ? 'rgba(239, 68, 68, 0.2)' : 'var(--error-bg, #fee2e2)',
                 borderRadius: '0.375rem',
                 padding: '0.15rem 0.4rem',
-                gap: '0.25rem'
+                gap: '0.25rem',
+                width: '50px'
               }}>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
                      style={{ width: '0.75rem', height: '0.75rem', color: 'var(--error-border, #ef4444)' }}>

--- a/src/components/TestDetail.tsx
+++ b/src/components/TestDetail.tsx
@@ -1323,7 +1323,7 @@ const TestDetail = () => {
                         alignItems: 'center',
                         gap: '0.5rem'
                       }}>
-                        Version Information
+                        Hive Version
                       </h4>
                       <VersionInfo hiveVersion={testDetail.runMetadata.hiveVersion} />
                     </div>
@@ -1341,7 +1341,6 @@ const TestDetail = () => {
                         alignItems: 'center',
                         gap: '0.5rem'
                       }}>
-                        <span>📄</span>
                         Client Configuration
                       </h4>
                       <ConfigViewer

--- a/src/components/TestDetail.tsx
+++ b/src/components/TestDetail.tsx
@@ -9,6 +9,9 @@ import Footer from './Footer';
 import { useTheme } from '../contexts/useTheme';
 import Breadcrumb from './Breadcrumb';
 import TestDetailsTable from './TestDetailsTable';
+import CommandDisplay from './CommandDisplay';
+import ConfigViewer from './ConfigViewer';
+import VersionInfo from './VersionInfo';
 
 const TestDetail = () => {
   const { isDarkMode } = useTheme();
@@ -1277,6 +1280,80 @@ const TestDetail = () => {
                   </div>
                 </div>
               </div>
+
+              {/* Detailed Metadata Section */}
+              {testDetail.runMetadata && (
+                <div style={{
+                  ...cardStyle,
+                  marginBottom: '1.5rem',
+                  backgroundColor: isDarkMode ? 'rgba(30, 41, 59, 0.8)' : '#ffffff'
+                }}>
+                  <h3 style={sectionTitleStyle}>Detailed Test Run Information</h3>
+
+                  <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
+                    gap: '1.5rem',
+                    marginTop: '1rem'
+                  }}>
+                    {/* Command Section */}
+                    <div>
+                      <h4 style={{
+                        fontSize: '0.875rem',
+                        fontWeight: '600',
+                        color: isDarkMode ? '#e5e7eb' : '#374151',
+                        marginBottom: '0.75rem',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.5rem'
+                      }}>
+                        Hive Command
+                      </h4>
+                      <CommandDisplay command={testDetail.runMetadata.hiveCommand} />
+                    </div>
+
+                    {/* Version Section */}
+                    <div>
+                      <h4 style={{
+                        fontSize: '0.875rem',
+                        fontWeight: '600',
+                        color: isDarkMode ? '#e5e7eb' : '#374151',
+                        marginBottom: '0.75rem',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.5rem'
+                      }}>
+                        Version Information
+                      </h4>
+                      <VersionInfo hiveVersion={testDetail.runMetadata.hiveVersion} />
+                    </div>
+                  </div>
+
+                  {/* Client Configuration Section */}
+                  {testDetail.runMetadata.clientConfig && (
+                    <div style={{ marginTop: '1.5rem' }}>
+                      <h4 style={{
+                        fontSize: '0.875rem',
+                        fontWeight: '600',
+                        color: isDarkMode ? '#e5e7eb' : '#374151',
+                        marginBottom: '0.75rem',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.5rem'
+                      }}>
+                        <span>📄</span>
+                        Client Configuration
+                      </h4>
+                      <ConfigViewer
+                        config={testDetail.runMetadata.clientConfig.content}
+                        filePath={testDetail.runMetadata.clientConfig.filePath}
+                        isDarkMode={isDarkMode}
+                        collapsed={true}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* Use the new TestDetailsTable component */}
               <TestDetailsTable

--- a/src/components/VersionInfo.tsx
+++ b/src/components/VersionInfo.tsx
@@ -8,10 +8,10 @@ interface VersionInfoProps {
   className?: string;
 }
 
-const VersionInfo: React.FC<VersionInfoProps> = ({ 
-  hiveVersion, 
-  compact = false, 
-  className = '' 
+const VersionInfo: React.FC<VersionInfoProps> = ({
+  hiveVersion,
+  compact = false,
+  className = ''
 }) => {
   const shortCommit = formatCommitHash(hiveVersion.commit);
   const formattedDate = formatCommitDate(hiveVersion.commitDate);
@@ -60,19 +60,6 @@ const VersionInfo: React.FC<VersionInfoProps> = ({
         alignItems: 'center',
         gap: '0.5rem'
       }}>
-        <span style={{ 
-          fontSize: '1rem',
-          color: 'var(--text-secondary, #6b7280)'
-        }}>
-          🔧
-        </span>
-        <span style={{
-          fontSize: '0.875rem',
-          fontWeight: '500',
-          color: 'var(--text-primary, #111827)'
-        }}>
-          Hive Version
-        </span>
       </div>
 
       <div style={{
@@ -83,7 +70,7 @@ const VersionInfo: React.FC<VersionInfoProps> = ({
       }}>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <span style={{ color: 'var(--text-secondary, #6b7280)' }}>Branch:</span>
-          <span style={{ 
+          <span style={{
             color: 'var(--text-primary, #111827)',
             fontWeight: '500',
             fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
@@ -95,7 +82,7 @@ const VersionInfo: React.FC<VersionInfoProps> = ({
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <span style={{ color: 'var(--text-secondary, #6b7280)' }}>Commit:</span>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <span style={{ 
+            <span style={{
               color: 'var(--text-primary, #111827)',
               fontWeight: '500',
               fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
@@ -120,7 +107,7 @@ const VersionInfo: React.FC<VersionInfoProps> = ({
 
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <span style={{ color: 'var(--text-secondary, #6b7280)' }}>Date:</span>
-          <span style={{ 
+          <span style={{
             color: 'var(--text-primary, #111827)',
             fontWeight: '400'
           }}>

--- a/src/components/VersionInfo.tsx
+++ b/src/components/VersionInfo.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { formatCommitDate, formatCommitHash, getVersionDisplayText } from '../utils/metadata';
+import { RunMetadata } from '../types';
+
+interface VersionInfoProps {
+  hiveVersion: RunMetadata['hiveVersion'];
+  compact?: boolean;
+  className?: string;
+}
+
+const VersionInfo: React.FC<VersionInfoProps> = ({ 
+  hiveVersion, 
+  compact = false, 
+  className = '' 
+}) => {
+  const shortCommit = formatCommitHash(hiveVersion.commit);
+  const formattedDate = formatCommitDate(hiveVersion.commitDate);
+  const versionText = getVersionDisplayText(hiveVersion);
+
+  if (compact) {
+    return (
+      <div
+        className={className}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          padding: '0.375rem 0.75rem',
+          backgroundColor: 'var(--badge-bg, #f3f4f6)',
+          border: '1px solid var(--border-color, rgba(229, 231, 235, 0.4))',
+          borderRadius: '0.375rem',
+          fontSize: '0.875rem',
+          fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
+        }}
+        title={`Hive ${versionText}\nCommit: ${hiveVersion.commit}\nDate: ${formattedDate}`}
+      >
+        <span style={{ color: 'var(--text-secondary, #6b7280)' }}>🔧</span>
+        <span style={{ color: 'var(--text-primary, #111827)', fontWeight: '500' }}>
+          {versionText}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        padding: '0.75rem',
+        backgroundColor: 'var(--card-bg, #ffffff)',
+        border: '1px solid var(--border-color, rgba(229, 231, 235, 0.4))',
+        borderRadius: '0.375rem'
+      }}
+    >
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem'
+      }}>
+        <span style={{ 
+          fontSize: '1rem',
+          color: 'var(--text-secondary, #6b7280)'
+        }}>
+          🔧
+        </span>
+        <span style={{
+          fontSize: '0.875rem',
+          fontWeight: '500',
+          color: 'var(--text-primary, #111827)'
+        }}>
+          Hive Version
+        </span>
+      </div>
+
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.375rem',
+        fontSize: '0.875rem'
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span style={{ color: 'var(--text-secondary, #6b7280)' }}>Branch:</span>
+          <span style={{ 
+            color: 'var(--text-primary, #111827)',
+            fontWeight: '500',
+            fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
+          }}>
+            {hiveVersion.branch}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span style={{ color: 'var(--text-secondary, #6b7280)' }}>Commit:</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span style={{ 
+              color: 'var(--text-primary, #111827)',
+              fontWeight: '500',
+              fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
+            }}>
+              {shortCommit}
+            </span>
+            {hiveVersion.dirty && (
+              <span style={{
+                padding: '0.125rem 0.375rem',
+                backgroundColor: 'var(--warning-bg, #fffbeb)',
+                color: 'var(--warning-text, #d97706)',
+                border: '1px solid var(--warning-border, #f59e0b)20',
+                borderRadius: '0.25rem',
+                fontSize: '0.75rem',
+                fontWeight: '500'
+              }}>
+                dirty
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span style={{ color: 'var(--text-secondary, #6b7280)' }}>Date:</span>
+          <span style={{ 
+            color: 'var(--text-primary, #111827)',
+            fontWeight: '400'
+          }}>
+            {formattedDate}
+          </span>
+        </div>
+      </div>
+
+      {/* Full commit hash in a collapsible/tooltip area */}
+      <details style={{ marginTop: '0.25rem' }}>
+        <summary style={{
+          cursor: 'pointer',
+          fontSize: '0.75rem',
+          color: 'var(--text-secondary, #6b7280)',
+          padding: '0.25rem 0',
+          borderTop: '1px solid var(--border-color, rgba(229, 231, 235, 0.4))',
+          marginTop: '0.25rem'
+        }}>
+          Full commit hash
+        </summary>
+        <div style={{
+          marginTop: '0.5rem',
+          padding: '0.5rem',
+          backgroundColor: 'var(--stat-bg, #f9fafb)',
+          border: '1px solid var(--border-color, rgba(229, 231, 235, 0.4))',
+          borderRadius: '0.25rem',
+          fontSize: '0.75rem',
+          fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          wordBreak: 'break-all',
+          color: 'var(--text-primary, #111827)'
+        }}>
+          {hiveVersion.commit}
+        </div>
+      </details>
+    </div>
+  );
+};
+
+export default VersionInfo;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,20 @@ export interface TestCaseDetail {
   clientInfo: Record<string, TestClientInfo>;
 }
 
+export interface RunMetadata {
+  hiveCommand: string[];
+  hiveVersion: {
+    commit: string;
+    commitDate: string;
+    branch: string;
+    dirty: boolean;
+  };
+  clientConfig?: {
+    filePath: string;
+    content: unknown;
+  };
+}
+
 export interface TestDetail {
   id: number;
   name: string;
@@ -57,6 +71,7 @@ export interface TestDetail {
   testCases: Record<string, TestCaseDetail>;
   simLog: string;
   testDetailsLog: string;
+  runMetadata?: RunMetadata;
 }
 
 export interface GitHubJob {

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,89 @@
+import { RunMetadata } from '../types';
+
+export function formatHiveCommand(command: string[]): string {
+  return command
+    .map(arg => {
+      if (arg.includes(' ') || arg.includes('"') || arg.includes("'")) {
+        return `"${arg.replace(/"/g, '\\"')}"`;
+      }
+      return arg;
+    })
+    .join(' ');
+}
+
+export function formatCommitDate(commitDate: string): string {
+  try {
+    const date = new Date(commitDate);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  } catch {
+    return commitDate;
+  }
+}
+
+export function formatCommitHash(commit: string): string {
+  return commit.length > 7 ? commit.substring(0, 7) : commit;
+}
+
+export function getVersionDisplayText(hiveVersion: RunMetadata['hiveVersion']): string {
+  const shortCommit = formatCommitHash(hiveVersion.commit);
+  const dirtyIndicator = hiveVersion.dirty ? ' (dirty)' : '';
+  return `${hiveVersion.branch}@${shortCommit}${dirtyIndicator}`;
+}
+
+export function parseConfigContent(content: unknown): { isValid: boolean; formatted: string } {
+  try {
+    if (typeof content === 'string') {
+      const parsed = JSON.parse(content);
+      return {
+        isValid: true,
+        formatted: JSON.stringify(parsed, null, 2)
+      };
+    } else if (typeof content === 'object') {
+      return {
+        isValid: true,
+        formatted: JSON.stringify(content, null, 2)
+      };
+    }
+    return {
+      isValid: false,
+      formatted: String(content)
+    };
+  } catch {
+    return {
+      isValid: false,
+      formatted: typeof content === 'string' ? content : String(content)
+    };
+  }
+}
+
+export function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(text)
+      .then(() => true)
+      .catch(() => false);
+  } else {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-999999px';
+    textArea.style.top = '-999999px';
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    
+    try {
+      const result = document.execCommand('copy');
+      document.body.removeChild(textArea);
+      return Promise.resolve(result);
+    } catch {
+      document.body.removeChild(textArea);
+      return Promise.resolve(false);
+    }
+  }
+}


### PR DESCRIPTION
As implemented in https://github.com/ethereum/hive/pull/1305

The metadata display feature adds significant value by showing:
  - Exact hive commands that were executed
  - Version information with commit details
  - Client configuration file