### PR TITLE
feat(TestResultGroup): add unique CSS class names for test result groups

### DIFF
--- a/src/components/TestResultGroup.tsx
+++ b/src/components/TestResultGroup.tsx
@@ -12,8 +12,24 @@ interface TestResultGroupProps {
 }
 
 const TestResultGroup = ({ groupKey, groupRuns, groupBy, directory, directoryAddress }: TestResultGroupProps) => {
+  // Create a sanitized class name from the groupKey.
+  // - Replace non-alphanumeric chars with hyphens
+  // - Replace multiple hyphens with single
+  // - Remove leading/trailing hyphens
+  const sanitizedClassName = groupKey
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const uniqueClassName = groupBy === 'client'
+    ? `client-box-${sanitizedClassName}`
+    : `test-box-${sanitizedClassName}`;
+
   return (
-    <div style={{
+    <div
+      className={uniqueClassName}
+      style={{
       backgroundColor: 'var(--card-bg, #ffffff)',
       borderRadius: '0.5rem',
       overflow: 'hidden',


### PR DESCRIPTION
- Added unique CSS class names to test result group boxes for easier DOM element targeting
- Enables headless browsers and automated testing tools to reliably select specific client/test boxes (eg: panda-pulse)