### PR TITLE
fix: increase pagination limit and fetch up to 100 jobs, from default 30

### DIFF
--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -37,7 +37,7 @@ function parseWorkflowUrl(url: string): { owner: string; repo: string; workflow:
 // Fetch jobs for a specific workflow run
 async function fetchJobsForRun(owner: string, repo: string, runId: number): Promise<GitHubJob[]> {
   try {
-    const apiUrl = `https://api.github.com/repos/${owner}/${repo}/actions/runs/${runId}/jobs`;
+    const apiUrl = `https://api.github.com/repos/${owner}/${repo}/actions/runs/${runId}/jobs?per_page=100`;
 
     const response = await fetch(apiUrl, {
       headers: getGitHubHeaders()


### PR DESCRIPTION
Currently the jobs were limited by 30 results due to the default page limit. 