### PR TITLE
Update hive source links to hive-tests repo

### DIFF
--- a/public/discovery.json
+++ b/public/discovery.json
@@ -10,14 +10,14 @@
     "name": "bal",
     "address": "https://hive.ethpandaops.io/bal/",
     "github_workflows": [
-      "https://github.com/ethpandaops/bal-devnets/actions/workflows/hive-devnet-3.yaml"
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-3.yaml"
     ]
   },
   {
     "name": "bal-quick",
     "address": "https://hive.ethpandaops.io/bal-quick/",
     "github_workflows": [
-      "https://github.com/ethpandaops/bal-devnets/actions/workflows/hive-devnet-3-quick.yaml"
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-3-quick.yaml"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- Updates `discovery.json` workflow links from `bal-devnets` to `hive-tests` repo
- Workflow filenames updated to `hive-bal.yaml` and `hive-bal-quick.yaml`

