### PR TITLE
feat(ui): improve stats, status labels, and card visuals

### DIFF
--- a/src/components/GroupDetail.tsx
+++ b/src/components/GroupDetail.tsx
@@ -467,11 +467,16 @@ const GroupDetail = () => {
   };
 
   const mostRecentRun = getMostRecentRun(testRuns);
+
+  // Compute filtered/grouped runs once for both header stats and card display
+  const filteredRuns = filterOldRuns(filterBySuites(filterByClients(testRuns)));
+  const groupedRuns = getGroupedRuns(filteredRuns, groupBy);
+  const displayedRuns = Object.values(groupedRuns).flat();
   const recentRuns = getRecentRuns(testRuns, 50);
 
-  // Check if directory is inactive (latest run > 7 days ago)
+  // Check if directory is inactive (latest run > 10 days ago)
   const isInactive = mostRecentRun ?
-    differenceInDays(new Date(), new Date(mostRecentRun.start)) > 7 :
+    differenceInDays(new Date(), new Date(mostRecentRun.start)) > 10 :
     false;
 
   // Get all available clients
@@ -597,7 +602,7 @@ const GroupDetail = () => {
               <GroupHeader
                 name={name!}
                 icon={dirIcons[name!]}
-                testRuns={testRuns}
+                testRuns={displayedRuns}
                 recentRuns={recentRuns}
                 mostRecentRun={mostRecentRun}
                 isInactive={isInactive}
@@ -1226,7 +1231,7 @@ const GroupDetail = () => {
 
               {!isSummaryCollapsed && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-                {Object.entries(getGroupedRuns(filterOldRuns(filterBySuites(filterByClients(testRuns))), groupBy)).map(([groupKey, groupRuns]) => (
+                {Object.entries(groupedRuns).map(([groupKey, groupRuns]) => (
                   <TestResultGroup
                     key={groupKey}
                     groupKey={groupKey}

--- a/src/components/GroupHeader.tsx
+++ b/src/components/GroupHeader.tsx
@@ -134,7 +134,7 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({
                   let barColor;
                   if (run.fails === 0) {
                     barColor = 'var(--success-border, #10b981)';
-                  } else if (run.passes > 0 && run.passes / run.ntests > 0.5) {
+                  } else if (run.ntests > 0 && run.fails / run.ntests < 0.01) {
                     barColor = 'var(--warning-border, #f59e0b)';
                   } else {
                     barColor = 'var(--error-border, #ef4444)';
@@ -144,7 +144,9 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({
                     <div
                       key={`${run.name}-${index}`}
                       style={{
-                        width: '4px',
+                        flex: 1,
+                        minWidth: '2px',
+                        maxWidth: '8px',
                         height: '8px',
                         backgroundColor: barColor,
                         borderRadius: '1px'
@@ -193,7 +195,7 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({
                      style={{ width: '0.75rem', height: '0.75rem', color: 'var(--warning-border, #f59e0b)' }}>
                   <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
                 </svg>
-                <span style={{ fontWeight: '500' }}>{testRuns.filter(r => r.fails > 0 && r.passes > 0 && r.passes / r.ntests > 0.5).length}</span>
+                <span style={{ fontWeight: '500' }}>{testRuns.filter(r => r.fails > 0 && r.ntests > 0 && r.fails / r.ntests < 0.01).length}</span>
               </div>
               <div style={{
                 display: 'flex',
@@ -208,7 +210,7 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({
                      style={{ width: '0.75rem', height: '0.75rem', color: 'var(--error-border, #ef4444)' }}>
                   <path fillRule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
                 </svg>
-                <span style={{ fontWeight: '500' }}>{testRuns.filter(r => r.fails > 0 && r.passes / r.ntests <= 0.5).length}</span>
+                <span style={{ fontWeight: '500' }}>{testRuns.filter(r => r.fails > 0 && (r.ntests === 0 || r.fails / r.ntests >= 0.01)).length}</span>
               </div>
             </div>
           </div>

--- a/src/components/Groups.tsx
+++ b/src/components/Groups.tsx
@@ -119,6 +119,18 @@ const Groups = () => {
       .slice(0, count);
   };
 
+  // Deduplicate runs to keep only the latest per (test name, client combination)
+  const getLatestRuns = (runs: TestRun[]): TestRun[] => {
+    const latest: Record<string, TestRun> = {};
+    runs.forEach(run => {
+      const key = `${run.name}::${run.clients.sort().join('+')}`;
+      if (!latest[key] || new Date(run.start) > new Date(latest[key].start)) {
+        latest[key] = run;
+      }
+    });
+    return Object.values(latest);
+  };
+
   return (
     <div className="space-y-8" style={{
       margin: '0.5rem',
@@ -136,9 +148,9 @@ const Groups = () => {
           const mostRecentRunB = getMostRecentRun(runsB);
 
           const isInactiveA = mostRecentRunA ?
-            differenceInDays(new Date(), new Date(mostRecentRunA.start)) > 7 : false;
+            differenceInDays(new Date(), new Date(mostRecentRunA.start)) > 10 : false;
           const isInactiveB = mostRecentRunB ?
-            differenceInDays(new Date(), new Date(mostRecentRunB.start)) > 7 : false;
+            differenceInDays(new Date(), new Date(mostRecentRunB.start)) > 10 : false;
 
           // Put inactive directories at the end
           if (isInactiveA && !isInactiveB) return 1;
@@ -150,10 +162,11 @@ const Groups = () => {
         .map(([directory, runs]) => {
           const mostRecentRun = getMostRecentRun(runs);
           const recentRuns = getRecentRuns(runs, 50);
+          const latestRuns = getLatestRuns(runs);
 
-          // Check if directory is inactive (latest run > 7 days ago)
+          // Check if directory is inactive (latest run > 10 days ago)
           const isInactive = mostRecentRun ?
-            differenceInDays(new Date(), new Date(mostRecentRun.start)) > 7 :
+            differenceInDays(new Date(), new Date(mostRecentRun.start)) > 10 :
             false;
 
           return (
@@ -196,7 +209,7 @@ const Groups = () => {
                   <GroupHeader
                     name={directory}
                     icon={dirIcons[directory]}
-                    testRuns={runs}
+                    testRuns={latestRuns}
                     recentRuns={recentRuns}
                     mostRecentRun={mostRecentRun}
                     isInactive={isInactive}

--- a/src/components/TestResultCard.tsx
+++ b/src/components/TestResultCard.tsx
@@ -178,7 +178,6 @@ const TestResultCard = ({ run, groupBy, directory, directoryAddress }: TestResul
 
               // Determine trend arrow
               let trendIndicator = '';
-              let trendColor = 'transparent';
 
               if (prevRun && !isCurrentRun) {
                 // Only show arrows when there's a meaningful change (>1% difference)
@@ -187,10 +186,8 @@ const TestResultCard = ({ run, groupBy, directory, directoryAddress }: TestResul
                 if (percentDiff >= 1) {
                   if (passRatio > prevPassRatio) {
                     trendIndicator = '↑';
-                    trendColor = 'var(--success-text, #047857)';
                   } else if (passRatio < prevPassRatio) {
                     trendIndicator = '↓';
-                    trendColor = 'var(--error-text, #b91c1c)';
                   }
                   // No arrow shown if exactly equal or minimal difference
                 }
@@ -198,10 +195,11 @@ const TestResultCard = ({ run, groupBy, directory, directoryAddress }: TestResul
 
               let barColor;
               let barGradient;
+              const failRatio = pastRun.ntests > 0 ? pastRun.fails / pastRun.ntests : 0;
               if (pastRun.fails === 0) {
                 barColor = 'var(--success-border, #10b981)';
                 barGradient = 'linear-gradient(180deg, #34d399 0%, #10b981 100%)';
-              } else if (passRatio > 0.5) {
+              } else if (failRatio < 0.01) {
                 barColor = 'var(--warning-border, #f59e0b)';
                 barGradient = 'linear-gradient(180deg, #fbbf24 0%, #f59e0b 100%)';
               } else {
@@ -249,14 +247,14 @@ const TestResultCard = ({ run, groupBy, directory, directoryAddress }: TestResul
                       {trendIndicator && (
                         <div style={{
                           position: 'absolute',
-                          top: '-3px',
+                          top: '50%',
                           left: '50%',
-                          transform: 'translateX(-50%)',
-                          fontSize: '0.7rem',
+                          transform: 'translate(-50%, -50%)',
+                          fontSize: '0.6rem',
                           fontWeight: '700',
-                          color: trendColor,
+                          color: 'white',
+                          textShadow: '0 0 2px rgba(0, 0, 0, 0.5)',
                           lineHeight: 1,
-                          textShadow: '0 0 1px var(--card-bg, white)',
                           zIndex: 2
                         }}>
                           {trendIndicator}
@@ -267,28 +265,13 @@ const TestResultCard = ({ run, groupBy, directory, directoryAddress }: TestResul
                           position: 'absolute',
                           bottom: 0,
                           width: '100%',
-                          height: `${Math.max(passRatio * 100, 5)}%`,
+                          height: '100%',
                           background: barGradient,
-                          borderTopLeftRadius: '2px',
-                          borderTopRightRadius: '2px',
-                          boxShadow: `0 -1px 2px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.2)`,
                           border: `1px solid ${barColor}`,
-                          borderBottom: 'none'
+                          borderBottom: 'none',
+                          borderRadius: '2px',
                         }}
                       />
-                      {/* Small highlight at top of bar for 3D effect */}
-                      {passRatio > 0.1 && (
-                        <div
-                          style={{
-                            position: 'absolute',
-                            bottom: `calc(${Math.max(passRatio * 100, 5)}% - 2px)`,
-                            width: '80%',
-                            height: '1px',
-                            backgroundColor: 'rgba(255, 255, 255, 0.5)',
-                            borderRadius: '1px'
-                          }}
-                        />
-                      )}
                     </div>
                   </Popover.Trigger>
 
@@ -390,10 +373,10 @@ const TestResultCard = ({ run, groupBy, directory, directoryAddress }: TestResul
               borderRadius: '0.25rem',
               color: 'var(--error-text, #b91c1c)',
               fontWeight: '600',
-              border: run.passes / run.ntests > 0.5
+              border: run.ntests > 0 && run.fails / run.ntests < 0.01
                 ? '1px solid var(--warning-border, #f59e0b)20'
                 : '1px solid var(--error-border, #ef4444)20',
-              background: run.passes / run.ntests > 0.5
+              background: run.ntests > 0 && run.fails / run.ntests < 0.01
                 ? 'var(--warning-bg, #fffbeb)'
                 : 'var(--error-bg, #fef2f2)'
             }}>

--- a/src/components/TestResultsTable.tsx
+++ b/src/components/TestResultsTable.tsx
@@ -65,7 +65,7 @@ const TestResultsTable = ({
     return saved ? JSON.parse(saved) : {
       date: 50,
       name: 50,
-      clients: 4500,
+      clients: 250,
       total: 100,
       pass: 100,
       fail: 100,

--- a/src/components/WorkflowStatus.tsx
+++ b/src/components/WorkflowStatus.tsx
@@ -409,36 +409,54 @@ const WorkflowStatus: React.FC<WorkflowStatusProps> = ({ workflowUrls, groupName
                       >
                         {run.name} #{run.run_number}
                       </a>
-                      {run.jobs && (
-                        <div style={{
-                          display: 'flex',
-                          gap: '0.25rem',
-                          fontSize: '0.75rem'
+                      <div style={{
+                        display: 'flex',
+                        gap: '0.25rem',
+                        fontSize: '0.75rem'
+                      }}>
+                        {runningJobs.length > 0 && (
+                          <span style={{
+                            padding: '0.125rem 0.375rem',
+                            borderRadius: '0.25rem',
+                            backgroundColor: isDarkMode ? 'rgba(251, 146, 60, 0.2)' : 'rgba(251, 146, 60, 0.1)',
+                            color: '#fb923c',
+                            border: '1px solid rgba(251, 146, 60, 0.3)'
+                          }}>
+                            {runningJobs.length} running
+                          </span>
+                        )}
+                        {failedJobs.length > 0 && (
+                          <span style={{
+                            padding: '0.125rem 0.375rem',
+                            borderRadius: '0.25rem',
+                            backgroundColor: isDarkMode ? 'rgba(239, 68, 68, 0.2)' : 'rgba(239, 68, 68, 0.1)',
+                            color: '#ef4444',
+                            border: '1px solid rgba(239, 68, 68, 0.3)'
+                          }}>
+                            {failedJobs.length} failed
+                          </span>
+                        )}
+                        <span style={{
+                          padding: '0.125rem 0.375rem',
+                          borderRadius: '0.25rem',
+                          backgroundColor: isDarkMode ? 'rgba(148, 163, 184, 0.15)' : 'rgba(100, 116, 139, 0.1)',
+                          color: isDarkMode ? '#94a3b8' : '#64748b',
+                          border: `1px solid ${isDarkMode ? 'rgba(148, 163, 184, 0.25)' : 'rgba(100, 116, 139, 0.2)'}`
                         }}>
-                          {runningJobs.length > 0 && (
-                            <span style={{
-                              padding: '0.125rem 0.375rem',
-                              borderRadius: '0.25rem',
-                              backgroundColor: isDarkMode ? 'rgba(251, 146, 60, 0.2)' : 'rgba(251, 146, 60, 0.1)',
-                              color: '#fb923c',
-                              border: '1px solid rgba(251, 146, 60, 0.3)'
-                            }}>
-                              {runningJobs.length} running
-                            </span>
-                          )}
-                          {failedJobs.length > 0 && (
-                            <span style={{
-                              padding: '0.125rem 0.375rem',
-                              borderRadius: '0.25rem',
-                              backgroundColor: isDarkMode ? 'rgba(239, 68, 68, 0.2)' : 'rgba(239, 68, 68, 0.1)',
-                              color: '#ef4444',
-                              border: '1px solid rgba(239, 68, 68, 0.3)'
-                            }}>
-                              {failedJobs.length} failed
-                            </span>
-                          )}
-                        </div>
-                      )}
+                          {run.event === 'schedule' ? 'cron' : run.event === 'workflow_dispatch' ? 'manual' : run.event}
+                        </span>
+                        {run.inputs?.client_source && (
+                          <span style={{
+                            padding: '0.125rem 0.375rem',
+                            borderRadius: '0.25rem',
+                            backgroundColor: isDarkMode ? 'rgba(59, 130, 246, 0.15)' : 'rgba(59, 130, 246, 0.1)',
+                            color: isDarkMode ? '#93c5fd' : '#3b82f6',
+                            border: `1px solid ${isDarkMode ? 'rgba(59, 130, 246, 0.25)' : 'rgba(59, 130, 246, 0.2)'}`
+                          }}>
+                            {run.inputs.client_source}
+                          </span>
+                        )}
+                      </div>
                     </div>
                     <div style={{
                       fontSize: '0.75rem',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,9 @@ export interface GitHubWorkflowRun {
   updated_at: string;
   run_number: number;
   run_attempt: number;
+  event: string;
+  triggering_actor?: { login: string };
+  inputs?: Record<string, string> | null;
   jobs?: GitHubJob[];
 }
 

--- a/src/utils/statusHelpers.ts
+++ b/src/utils/statusHelpers.ts
@@ -8,7 +8,7 @@ export const getStatusStyles = (run: TestRun) => {
       text: 'var(--success-text, #047857)',
       border: 'var(--success-border, #10b981)',
       icon: '✓',
-      label: 'Success',
+      label: 'Passing',
       pattern: 'radial-gradient(circle at 100% 100%, transparent 15%, rgba(16, 185, 129, 0.05) 25%, transparent 30%), linear-gradient(135deg, rgba(16, 185, 129, 0.05) 0%, var(--card-bg, #ffffff) 100%)'
     };
   } else if (run.timeout) {
@@ -20,14 +20,14 @@ export const getStatusStyles = (run: TestRun) => {
       label: 'Timeout',
       pattern: 'linear-gradient(45deg, rgba(245, 158, 11, 0.05) 25%, transparent 25%, transparent 50%, rgba(245, 158, 11, 0.05) 50%, rgba(245, 158, 11, 0.05) 75%, transparent 75%, transparent) 0 0 / 8px 8px, linear-gradient(135deg, rgba(245, 158, 11, 0.05) 0%, var(--card-bg, #ffffff) 100%)'
     };
-  } else if (run.passes > 0 && run.passes / run.ntests > 0.5) {
-    // More than 50% passed but not all
+  } else if (run.ntests > 0 && run.fails / run.ntests < 0.01) {
+    // Less than 1% failed
     return {
       bg: 'var(--warning-bg, #fffbeb)',
       text: 'var(--warning-text, #b45309)',
       border: 'var(--warning-border, #f59e0b)',
       icon: '⚠',
-      label: 'Failed',
+      label: 'Failing',
       pattern: 'linear-gradient(45deg, rgba(245, 158, 11, 0.05) 25%, transparent 25%, transparent 50%, rgba(245, 158, 11, 0.05) 50%, rgba(245, 158, 11, 0.05) 75%, transparent 75%, transparent) 0 0 / 8px 8px, linear-gradient(135deg, rgba(245, 158, 11, 0.05) 0%, var(--card-bg, #ffffff) 100%)'
     };
   } else {
@@ -36,7 +36,7 @@ export const getStatusStyles = (run: TestRun) => {
       text: 'var(--error-text, #b91c1c)',
       border: 'var(--error-border, #ef4444)',
       icon: '✕',
-      label: 'Error',
+      label: 'Failing',
       pattern: 'repeating-linear-gradient(-45deg, rgba(239, 68, 68, 0.05) 0, rgba(239, 68, 68, 0.05) 2px, transparent 2px, transparent 6px), linear-gradient(135deg, rgba(239, 68, 68, 0.05) 0%, var(--card-bg, #ffffff) 100%)'
     };
   }


### PR DESCRIPTION
Small UI tweaks for better UX (imo):
- Summary stats now use filtered/grouped runs matching displayed cards
- Deduplicate home page run counts (latest per test/client combo)
- Align inactive threshold to 10 days to match hide-old-jobs filter
- Status labels: Passing/Failing with <1% fail threshold for orange/red
- CI workflow badges show trigger type (cron/manual) and client source
- Progress bar tiles flex to fill available width
- Card bars solid color at 100% height, trend arrows centered white
- Fix table clients column default from 4500px to 250px


### Before

<img width="1446" height="725" alt="Screenshot 2026-03-27 at 13 09 42" src="https://github.com/user-attachments/assets/a6d8f72b-db9c-400e-ab13-f617df863701" />

### After

<img width="1448" height="657" alt="Screenshot 2026-03-27 at 13 09 58" src="https://github.com/user-attachments/assets/290cb84d-c66b-44f7-a3db-deaa9319c391" />
