### PR TITLE
chore(hive): point BAL workflow links at hive-devnet-4

### DIFF
--- a/public/discovery.json
+++ b/public/discovery.json
@@ -10,14 +10,14 @@
     "name": "bal",
     "address": "https://hive.ethpandaops.io/bal/",
     "github_workflows": [
-      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-3.yaml"
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-4.yaml"
     ]
   },
   {
     "name": "bal-quick",
     "address": "https://hive.ethpandaops.io/bal-quick/",
     "github_workflows": [
-      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-3-quick.yaml"
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-4-quick.yaml"
     ]
   }
 ]


### PR DESCRIPTION
The hive-tests workflows were renamed from `hive-devnet-3{,-quick}.yaml` to `hive-devnet-4{,-quick}.yaml` when the single BAL track was retargeted at bal-devnet-4 (ethpandaops/hive-tests#46). Update the `github_workflows` deep-links in `discovery.json` so the "Workflow" buttons on the `bal` / `bal-quick` UI cards stop 404ing.

No entries added or renamed — just the deep-link URLs.