### PR TITLE
chore(discovery): add snobal-devnet-5-quick endpoint

### DIFF
--- a/public/discovery.json
+++ b/public/discovery.json
@@ -19,5 +19,12 @@
     "github_workflows": [
       "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-4-quick.yaml"
     ]
+  },
+  {
+    "name": "snobal-devnet-5-quick",
+    "address": "https://hive.ethpandaops.io/snobal-devnet-5-quick/",
+    "github_workflows": [
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-snobal-devnet-5-quick.yaml"
+    ]
   }
 ]

--- a/public/discovery.json
+++ b/public/discovery.json
@@ -21,6 +21,13 @@
     ]
   },
   {
+    "name": "snobal-devnet-5",
+    "address": "https://hive.ethpandaops.io/snobal-devnet-5/",
+    "github_workflows": [
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-snobal-devnet-5.yaml"
+    ]
+  },
+  {
     "name": "snobal-devnet-5-quick",
     "address": "https://hive.ethpandaops.io/snobal-devnet-5-quick/",
     "github_workflows": [


### PR DESCRIPTION
## Summary
- Adds a `discovery.json` entry for the new SNOBAL devnet-5 quick workflow ([ethpandaops/hive-tests#47](https://github.com/ethpandaops/hive-tests/pull/47)) so the UI surfaces its results at `https://hive.ethpandaops.io/snobal-devnet-5-quick/`.
- Existing `bal` / `bal-quick` entries left in place so historical results remain accessible. Their schedules are disabled in hive-tests; we can prune these entries in a follow-up once we no longer need historical access.

## Test plan
- [ ] `discovery.json` parses as valid JSON (validated locally)
- [ ] After deploy + first scheduled run of the new workflow, confirm the `snobal-devnet-5-quick` endpoint shows up in the UI and loads `listing.jsonl` from S3