### PR TITLE
feat: add glamsterdam-devnet-6 discovery entries

### DIFF
--- a/public/discovery.json
+++ b/public/discovery.json
@@ -19,5 +19,19 @@
     "github_workflows": [
       "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-7-quick.yaml"
     ]
+  },
+  {
+    "name": "glamsterdam",
+    "address": "https://hive.ethpandaops.io/glamsterdam/",
+    "github_workflows": [
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-glamsterdam-devnet-6.yaml"
+    ]
+  },
+  {
+    "name": "glamsterdam-quick",
+    "address": "https://hive.ethpandaops.io/glamsterdam-quick/",
+    "github_workflows": [
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-glamsterdam-devnet-6-quick.yaml"
+    ]
   }
 ]


### PR DESCRIPTION
Adds `glamsterdam` and `glamsterdam-quick` discovery entries pointing at the renamed Hive workflows from ethpandaops/hive-tests#60.

| name | address | workflow |
|---|---|---|
| `glamsterdam` | `https://hive.ethpandaops.io/glamsterdam/` | `hive-glamsterdam-devnet-6.yaml` |
| `glamsterdam-quick` | `https://hive.ethpandaops.io/glamsterdam-quick/` | `hive-glamsterdam-devnet-6-quick.yaml` |

The existing `bal` / `bal-quick` entries are kept for now; a separate follow-up PR removes them once glamsterdam results are confirmed.