### PR TITLE
chore: remove bal devnet discovery entries

### DIFF
--- a/public/discovery.json
+++ b/public/discovery.json
@@ -5,19 +5,5 @@
     "github_workflows": [
       "https://github.com/ethpandaops/hive-tests/actions/workflows/generic.yaml"
     ]
-  },
-  {
-    "name": "bal",
-    "address": "https://hive.ethpandaops.io/bal/",
-    "github_workflows": [
-      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-7.yaml"
-    ]
-  },
-  {
-    "name": "bal-quick",
-    "address": "https://hive.ethpandaops.io/bal-quick/",
-    "github_workflows": [
-      "https://github.com/ethpandaops/hive-tests/actions/workflows/hive-devnet-7-quick.yaml"
-    ]
   }
 ]


### PR DESCRIPTION
Removes the `bal` and `bal-quick` discovery entries, now superseded by the `glamsterdam` / `glamsterdam-quick` entries added in #72.

Their workflows were renamed and retargeted in ethpandaops/hive-tests#60 (`bal`/`bal-quick` S3 paths → `glamsterdam`/`glamsterdam-quick`), so the old entries no longer receive results.

**Merge after #72.** The two PRs touch independent lines (#72 appends, this deletes the `bal` blocks), so they apply cleanly in either order; merging this first would temporarily leave only the `generic` entry.