### PR TITLE
docs: add llms.txt and ai.md for AI-friendly data access

### DIFF
--- a/public/ai.md
+++ b/public/ai.md
@@ -4,9 +4,11 @@ This page documents how to read Ethereum Hive test results directly as machine-r
 data from `https://hive.ethpandaops.io`, without scraping the UI.
 
 The website is a static React single-page app. Everything it renders is fetched from
-plain **JSON** and **JSONL** files served at predictable URLs. All files are public,
-require no authentication, and are served with permissive CORS, so any HTTP client or
-AI agent can fetch them directly.
+plain **JSON** and **JSONL** files served at predictable URLs. All files are public and
+require no authentication, so any server-side HTTP client or AI agent (curl, Python,
+etc.) can fetch them directly. Note: the files are served same-origin and are **not**
+CORS-enabled, so a browser-based agent cannot fetch them cross-origin with `fetch()` —
+use a non-browser HTTP client.
 
 > Quick index for agents: [/llms.txt](https://hive.ethpandaops.io/llms.txt)
 
@@ -40,18 +42,24 @@ Returns a JSON array of test groups:
 | Field              | Type       | Description                                              |
 | ------------------ | ---------- | -------------------------------------------------------- |
 | `name`             | string     | Human-readable group name.                               |
-| `address`          | string     | Base URL for the group's data (may have a trailing `/`). |
+| `address`          | string     | Base URL for the group's data (ends with a trailing `/`). |
 | `github_workflows` | string[]?  | Optional GitHub Actions workflow URLs that produce it.   |
 
-Use `address` as the base for the next steps. Trailing slashes are optional —
-normalize as needed.
+Use `address` as the base for the next steps. **The `address` value ends with a
+trailing slash** (e.g. `https://hive.ethpandaops.io/generic/`). In the URL templates
+below, `{address}` means this value **with the trailing slash stripped** — building
+`{address}/listing.jsonl` without stripping it yields a double slash (`…/generic//listing.jsonl`)
+that returns 404. Normalize with e.g. `sed 's:/*$::'` (as in the recipe below).
 
 ## 2. List the runs in a group
 
 `GET {address}/listing.jsonl`
 
 This is **JSONL**: newline-delimited JSON, one test run per line. Parse it by splitting
-on `\n` and `JSON.parse`-ing each non-empty line.
+on `\n` and `JSON.parse`-ing each non-empty line. Parse each line independently and
+tolerate per-line failures: some lines embed client version strings containing raw
+control characters, which strict streaming parsers (e.g. `jq`) reject — skip the
+offending line rather than aborting the whole stream.
 
 Each line (a `TestRun`):
 
@@ -146,7 +154,7 @@ Each `TestCase`:
 | `start` / `end`       | string (ISO 8601)          | Case timing.                                             |
 | `summaryResult.pass`  | boolean                    | Pass/fail for this case.                                 |
 | `summaryResult.log`   | `{ begin, end }`           | **Byte offsets** into `simLog` for this case's output.   |
-| `clientInfo`          | object<string, ClientInfo> | Per-client runtime info (id, ip, name, logFile, etc.).   |
+| `clientInfo`          | object<string, ClientInfo>? | Per-client runtime info (id, ip, name, logFile, etc.). May be `null` for some cases. |
 
 ## 4. Read raw logs
 

--- a/public/ai.md
+++ b/public/ai.md
@@ -1,0 +1,193 @@
+# Accessing Hive test data programmatically
+
+This page documents how to read Ethereum Hive test results directly as machine-readable
+data from `https://hive.ethpandaops.io`, without scraping the UI.
+
+The website is a static React single-page app. Everything it renders is fetched from
+plain **JSON** and **JSONL** files served at predictable URLs. All files are public,
+require no authentication, and are served with permissive CORS, so any HTTP client or
+AI agent can fetch them directly.
+
+> Quick index for agents: [/llms.txt](https://hive.ethpandaops.io/llms.txt)
+
+## Overview of the data flow
+
+```
+discovery.json            ── list of test groups (with base addresses)
+   └─ {address}/listing.jsonl        ── one line per test run (summary)
+        └─ {address}/results/{fileName}   ── full detail for a single run
+             └─ {address}/results/{simLog}   ── raw simulator/client log (text)
+```
+
+## 1. Discover test groups
+
+`GET https://hive.ethpandaops.io/discovery.json`
+
+Returns a JSON array of test groups:
+
+```json
+[
+  {
+    "name": "generic",
+    "address": "https://hive.ethpandaops.io/generic/",
+    "github_workflows": [
+      "https://github.com/ethpandaops/hive-tests/actions/workflows/generic.yaml"
+    ]
+  }
+]
+```
+
+| Field              | Type       | Description                                              |
+| ------------------ | ---------- | -------------------------------------------------------- |
+| `name`             | string     | Human-readable group name.                               |
+| `address`          | string     | Base URL for the group's data (may have a trailing `/`). |
+| `github_workflows` | string[]?  | Optional GitHub Actions workflow URLs that produce it.   |
+
+Use `address` as the base for the next steps. Trailing slashes are optional —
+normalize as needed.
+
+## 2. List the runs in a group
+
+`GET {address}/listing.jsonl`
+
+This is **JSONL**: newline-delimited JSON, one test run per line. Parse it by splitting
+on `\n` and `JSON.parse`-ing each non-empty line.
+
+Each line (a `TestRun`):
+
+```json
+{
+  "name": "engine-withdrawals",
+  "ntests": 35,
+  "passes": 34,
+  "fails": 1,
+  "timeout": false,
+  "clients": ["reth_default"],
+  "versions": { "reth_default": "Reth Version: 2.3.0+1c462acf" },
+  "start": "2026-06-24T08:59:51Z",
+  "fileName": "1782291920-04666365c80770ba706c712fff723fe2.json",
+  "size": 29088,
+  "simLog": "1782291150-simulator-df8b...400.log"
+}
+```
+
+| Field      | Type                   | Description                                                |
+| ---------- | ---------------------- | ---------------------------------------------------------- |
+| `name`     | string                 | Test suite name.                                           |
+| `ntests`   | number                 | Total number of test cases in the run.                     |
+| `passes`   | number                 | Number of passing cases.                                   |
+| `fails`    | number                 | Number of failing cases. **Filter `fails > 0` for failures.** |
+| `timeout`  | boolean                | Whether the run timed out.                                 |
+| `clients`  | string[]               | Clients under test.                                        |
+| `versions` | object<string,string>  | Map of client name → version string.                       |
+| `start`    | string (ISO 8601)      | Run start time.                                            |
+| `fileName` | string                 | File to fetch for full detail (see step 3).                |
+| `size`     | number                 | Size of the detail file in bytes.                          |
+| `simLog`   | string                 | Filename of the raw simulator log (see step 4).            |
+
+## 3. Fetch full detail for a run
+
+`GET {address}/results/{fileName}`
+
+Where `{fileName}` is the `fileName` from a listing line. Returns a `TestDetail`:
+
+```json
+{
+  "id": 0,
+  "name": "engine-withdrawals",
+  "description": "...",
+  "clientVersions": { "reth_default": "Reth Version: 2.3.0+1c462acf" },
+  "testCases": {
+    "1": {
+      "name": "Withdrawals fork on Block 1 ...",
+      "description": "",
+      "start": "2026-06-24T08:59:51Z",
+      "end": "2026-06-24T09:00:10Z",
+      "summaryResult": {
+        "pass": false,
+        "log": { "begin": 10240, "end": 20480 }
+      },
+      "clientInfo": {
+        "reth_default": {
+          "id": "reth_default",
+          "ip": "172.17.0.3",
+          "name": "reth_default",
+          "instantiatedAt": "2026-06-24T08:59:51Z",
+          "logFile": "reth_default.log"
+        }
+      }
+    }
+  },
+  "simLog": "1782291150-simulator-...log",
+  "testDetailsLog": "",
+  "runMetadata": {
+    "hiveCommand": ["hive", "--sim", "ethereum/engine"],
+    "hiveVersion": { "commit": "...", "commitDate": "...", "branch": "...", "dirty": false }
+  }
+}
+```
+
+Key fields:
+
+| Field             | Type                          | Description                                              |
+| ----------------- | ----------------------------- | -------------------------------------------------------- |
+| `name`            | string                        | Suite name.                                              |
+| `clientVersions`  | object<string,string>         | Client → version under test.                             |
+| `testCases`       | object<string, TestCase>      | Map of case id → case detail.                            |
+| `simLog`          | string                        | Raw simulator log filename (see step 4).                 |
+| `runMetadata`     | object?                       | Hive command/version metadata for the run.               |
+
+Each `TestCase`:
+
+| Field                 | Type                       | Description                                              |
+| --------------------- | -------------------------- | -------------------------------------------------------- |
+| `name`                | string                     | Test case name.                                          |
+| `description`         | string                     | Test case description.                                   |
+| `start` / `end`       | string (ISO 8601)          | Case timing.                                             |
+| `summaryResult.pass`  | boolean                    | Pass/fail for this case.                                 |
+| `summaryResult.log`   | `{ begin, end }`           | **Byte offsets** into `simLog` for this case's output.   |
+| `clientInfo`          | object<string, ClientInfo> | Per-client runtime info (id, ip, name, logFile, etc.).   |
+
+## 4. Read raw logs
+
+`GET {address}/results/{simLog}`
+
+Returns the raw simulator log as **plain text**. To read only one test case's slice,
+use the `summaryResult.log.{begin,end}` byte offsets with an HTTP Range request:
+
+```
+Range: bytes={begin}-{end}
+```
+
+## End-to-end recipe: find and explain failing tests
+
+```bash
+BASE="https://hive.ethpandaops.io"
+
+# 1. Pick a group's address from discovery.json
+ADDR=$(curl -s "$BASE/discovery.json" | jq -r '.[0].address' | sed 's:/*$::')
+
+# 2. Find runs with failures
+curl -s "$ADDR/listing.jsonl" \
+  | while read -r line; do echo "$line"; done \
+  | jq -c 'select(.fails > 0) | {name, fails, clients, fileName}'
+
+# 3. For one failing run, list the failing cases
+curl -s "$ADDR/results/<fileName>" \
+  | jq -r '.testCases | to_entries[] | select(.value.summaryResult.pass == false)
+           | "\(.value.name)  bytes \(.value.summaryResult.log.begin)-\(.value.summaryResult.log.end)"'
+
+# 4. Read just the failing case's log slice
+curl -s -r 10240-20480 "$ADDR/results/<simLog>"
+```
+
+## Notes for agents
+
+- Prefer these data files over parsing the HTML UI; the HTML is just a renderer.
+- The UI appends a `?ts=<epoch-ms>` cache-buster to `discovery.json` and `listing.jsonl`.
+  You can do the same to avoid stale CDN responses, but it is not required.
+- `discovery.json` is the single source of truth for which groups currently exist —
+  read it live rather than hardcoding group names.
+- GitHub workflow status (when present in `github_workflows`) is fetched separately from
+  the GitHub REST API (`api.github.com/repos/{owner}/{repo}/actions/...`) and is subject
+  to GitHub rate limits.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,13 +1,13 @@
 # Hive UI (hive.ethpandaops.io)
 
-> Web interface for [Hive](https://github.com/ethereum/hive), the Ethereum client integration-testing framework. The site is a static React app rendered over plain JSON/JSONL files. Every piece of data the UI shows is also directly fetchable as raw JSON — no API key, no auth, CORS-enabled. AI agents should read the data files below instead of scraping the HTML.
+> Web interface for [Hive](https://github.com/ethereum/hive), the Ethereum client integration-testing framework. The site is a static React app rendered over plain JSON/JSONL files. Every piece of data the UI shows is also directly fetchable as raw JSON — no API key, no auth. Files are served same-origin (not CORS-enabled), so use a non-browser HTTP client. AI agents should read the data files below instead of scraping the HTML.
 
 For full schemas, field descriptions, and copy-paste recipes, read [/ai.md](https://hive.ethpandaops.io/ai.md).
 
 ## Data access (3-step flow)
 
 1. **Discover test groups** — `GET https://hive.ethpandaops.io/discovery.json`
-   JSON array of `{ name, address, github_workflows? }`. `address` is the base URL for a group.
+   JSON array of `{ name, address, github_workflows? }`. `address` is the base URL for a group and ends with a trailing slash; strip it before building the URLs below (`{address}` = address without trailing slash) to avoid a double-slash 404.
 2. **List runs in a group** — `GET {address}/listing.jsonl`
    JSONL (one JSON object per line). Each line summarizes a run: `name, ntests, passes, fails, timeout, clients[], versions{}, start, fileName, size, simLog`. Filter for `fails > 0` to find failures.
 3. **Full run detail** — `GET {address}/results/{fileName}`

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,24 @@
+# Hive UI (hive.ethpandaops.io)
+
+> Web interface for [Hive](https://github.com/ethereum/hive), the Ethereum client integration-testing framework. The site is a static React app rendered over plain JSON/JSONL files. Every piece of data the UI shows is also directly fetchable as raw JSON — no API key, no auth, CORS-enabled. AI agents should read the data files below instead of scraping the HTML.
+
+For full schemas, field descriptions, and copy-paste recipes, read [/ai.md](https://hive.ethpandaops.io/ai.md).
+
+## Data access (3-step flow)
+
+1. **Discover test groups** — `GET https://hive.ethpandaops.io/discovery.json`
+   JSON array of `{ name, address, github_workflows? }`. `address` is the base URL for a group.
+2. **List runs in a group** — `GET {address}/listing.jsonl`
+   JSONL (one JSON object per line). Each line summarizes a run: `name, ntests, passes, fails, timeout, clients[], versions{}, start, fileName, size, simLog`. Filter for `fails > 0` to find failures.
+3. **Full run detail** — `GET {address}/results/{fileName}`
+   JSON with `testCases{}`; each case has `summaryResult.pass` and `summaryResult.log.{begin,end}` (byte offsets into the sim log).
+
+## Logs
+
+- Raw simulator/client logs — `GET {address}/results/{simLog}` (plain text; supports HTTP Range requests for partial reads using the `log.begin`/`log.end` byte offsets).
+
+## Examples
+
+- Groups index: https://hive.ethpandaops.io/discovery.json
+- Run listing: https://hive.ethpandaops.io/generic/listing.jsonl
+- Run detail: https://hive.ethpandaops.io/generic/results/{fileName-from-listing}


### PR DESCRIPTION
## What

Adds two static docs to `public/` (which deploy to the site root) so AI agents can discover and read Hive test data directly as raw JSON instead of scraping the React UI:

- **`public/llms.txt`** → `https://hive.ethpandaops.io/llms.txt` — short, agent-oriented index following the emerging `llms.txt` convention.
- **`public/ai.md`** → `https://hive.ethpandaops.io/ai.md` — full reference: endpoint URLs, field-by-field schemas, and a copy-paste recipe for finding failing tests.

## Why

Everything the UI renders is already fetched from public, CORS-enabled, auth-free JSON/JSONL files at predictable URLs. The data was always AI-friendly — the only missing piece was **discoverability**. These docs give agents a map:

1. `GET /discovery.json` — list test groups + base addresses
2. `GET {address}/listing.jsonl` — one run summary per line (filter `fails > 0`)
3. `GET {address}/results/{fileName}` — full run detail with per-case pass/fail + log byte offsets
4. `GET {address}/results/{simLog}` — raw log text (Range-request the byte offsets)

## Notes

- No backend or data-format changes — documentation only.
- Schemas in `ai.md` are derived from `src/types/index.ts` so they match the real fields.
- Vite copies `public/*` to the build root, so no routing/build changes are needed.